### PR TITLE
Add PDF transaction section extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # streamlit_pdf_editeur
+
+Cette application Streamlit permet de modifier un fichier PDF directement dans le navigateur. Les fonctionnalités proposées sont :
+
+- Remplacement de texte par recherche exacte.
+- Suppression de toutes les images d'un document.
+- **Extraction automatique du contenu compris entre les mots "TRANSACTIONS" et "APERÇU DU SOLDE".** Tout le reste (texte et images) est supprimé.
+- Téléchargement du PDF obtenu après traitement.
+
+Installez les dépendances avec :
+```
+pip install -r requirements.txt
+```


### PR DESCRIPTION
## Summary
- add checkbox to keep only the pages between `TRANSACTIONS` and `APERÇU DU SOLDE`
- redact and delete pages outside that range
- update help text and README with new feature

## Testing
- `python -m py_compile streamlit_pdf_editeur.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb4f738048331bad5a3e251870b79